### PR TITLE
Bump faf-replay-parser to 0.4.0

### DIFF
--- a/replayserver/bookkeeping/analyzer.py
+++ b/replayserver/bookkeeping/analyzer.py
@@ -1,14 +1,8 @@
-from fafreplay import Parser, ReplayReadError, commands
+from fafreplay import ReplayReadError, body_ticks
 from replayserver.errors import BookkeepingError
 
 
 class ReplayAnalyzer:
-    def __init__(self):
-        self._parser = Parser(
-            commands=[commands.Advance],
-            save_commands=False
-        )
-
     def get_replay_ticks(self, data):
         """Parse the replay data and extract the total number of ticks
 
@@ -21,8 +15,6 @@ class ReplayAnalyzer:
             raise BookkeepingError("No replay data")
 
         try:
-            replay_body = self._parser.parse_body(bytes(data))
-
-            return replay_body["sim"]["tick"]
+            return body_ticks(data)
         except ReplayReadError as e:
             raise BookkeepingError(f"Failed to parse replay: {e}")

--- a/requirements/main-pinned.txt
+++ b/requirements/main-pinned.txt
@@ -62,13 +62,13 @@ cryptography==2.7 \
 everett[yaml]==1.0.2 \
     --hash=sha256:66c7991c056fd9b1de54c29e2b5004a30209530faef698d6ecfbf24bfbbdd1fb \
     --hash=sha256:8a5ee8cdde0ed6b3bbb63249e0e0703d4ad91921107ff198e0868ffce5f7b6bc
-faf-replay-parser==0.3.1 \
-    --hash=sha256:2f2d63fafa449b494a9516ae2fd66f397d6000116da6ee7141a07baa8e3339b3 \
-    --hash=sha256:7684929541ed7f14891ca874486fc7c914ea4dea8786498233e80854957ce8fa \
-    --hash=sha256:76ab66a03e14d087fb7c04bef45620253787b023bcfc87e1fc946351b1f24490 \
-    --hash=sha256:81ce24f6bbba0b215ccba06d86f97912a0e210d34001227693829cec2fbca42d \
-    --hash=sha256:9a8e5710530baea157c5bf0cdc2f6d64c8a73cc44d2ac5385b48569b60d5fdcf \
-    --hash=sha256:b9d5dfdf99b3af16aaf392880593ff515002b6e04066781bbef4071c96971190
+faf-replay-parser==0.4.0 \
+    --hash=sha256:500e59ca2d419daa4ee7d899e3f417e3e442d9eca31d390b3798b7bd230bc7db \
+    --hash=sha256:606730f9f466ec5a7244d99a8a189989f361f207d3ccf8b066cb8dc4bc1a89cf \
+    --hash=sha256:65c45c537c15c7b9fec279070ae20c446412e10ed31a4efb99214ed1ae9992b9 \
+    --hash=sha256:b14dcb0d40d0cbeeb6f1abb8f38f798b8daa8cd714e2514c6af531c727584e6d \
+    --hash=sha256:d2ad3ce3ead94572ea3370e73b031193a8675d44cfd4cfbecb5c40d59718906a \
+    --hash=sha256:eaa0682f2c374c9c3d271073b6db9428459dfd521de227aafffb767e8cf7bfaf
 prometheus-client==0.7.1 \
     --hash=sha256:71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da
 pycparser==2.19 \

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=long_desc,
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     author="Igor Kotrasiński, Konstantin Kalinovsky",
     author_email="i.kotrasinsk@gmail.com",


### PR DESCRIPTION
I needed a break from python yesterday so I went back to my replay parsing library. I figured since the only thing it's being used for in production is to extract the tick count from replays, that I might as well write a dedicated, optimized function for it. 

This new function doesn't need to create and return a python dict, it just returns an integer, and it can also accept a `bytearray` object so that we can avoid the extra copy from `bytes`.

Here is some timing analysis:
```python
>>> import timeit
>>> from fafreplay import Parser, commands, body_offset, body_ticks
>>> parser = Parser(
...     commands=[commands.Advance],
...     save_commands=False
... )
>>> with open("tests/data/6176549.scfareplay", "rb") as f:
...     data = f.read()
... 
>>> body_data = data[body_offset(data):]
>>> timeit.timeit("parser.parse_body(body_data)['sim']['tick']", globals=globals(), number=100)
1.525173360016197
>>> timeit.timeit("body_ticks(body_data)", globals=globals(), number=100)                                           
0.20764156704535708
>>> len(body_data)
5586339
>>> body_ticks(body_data)
28917
>>> 1.525173360016197 / 0.20764156704535708
7.345221776731434
>>> body_data_ba = bytearray(body_data)
>>> timeit.timeit("parser.parse_body(bytes(body_data_ba))['sim']['tick']", globals=globals(), number=100)
1.604606525041163
>>> timeit.timeit("body_ticks(bytes(body_data_ba))", globals=globals(), number=100)                                
0.3146446730243042
>>> 1.604606525041163 / 0.20764156704535708
7.727771215917735
```

So with the removal of the extra `bytes` call and the use of the new function, the tick extraction was between 7-8 times faster on this particular replay. 